### PR TITLE
Add `var` keyword to `code`

### DIFF
--- a/src/language/code.md
+++ b/src/language/code.md
@@ -21,7 +21,7 @@ Pug 也支持把它们写成一个块的形式：
 
 ```pug-preview
 -
-  list = ["Uno", "Dos", "Tres",
+  var list = ["Uno", "Dos", "Tres",
           "Cuatro", "Cinco", "Seis"]
 each item in list
   li= item


### PR DESCRIPTION
Fix to match consistent use of var throughout the documentation
